### PR TITLE
Sustitution updates, etc

### DIFF
--- a/src/data/ingredient-data.ts
+++ b/src/data/ingredient-data.ts
@@ -36,7 +36,7 @@ const currentIngredients: StaticIngredient[] = [
     // https://en.wikipedia.org/wiki/Rum
     // From 40 to 80. Used 40
     { id: '22', translation: 'amaretto', spiritType: SpiritType.None, abv: 24.0 },
-    { id: '23', translation: 'egg-white', spiritType: SpiritType.None, replacementIds: ['114'] },
+    { id: '23', translation: 'egg-white', spiritType: SpiritType.None, replacementIds: ['94', '114'] },
     { id: '24', translation: 'ginger-beer', spiritType: SpiritType.None },
     { id: '25', translation: 'coconut-cream', spiritType: SpiritType.None },
     { id: '26', translation: 'pineapple-juice', spiritType: SpiritType.None },
@@ -151,7 +151,7 @@ const currentIngredients: StaticIngredient[] = [
     { id: '93', translation: 'pisco', spiritType: SpiritType.None, abv: 40 },
     // https://en.wikipedia.org/wiki/Pisco
     // Unknown. Used a tentative 40
-    { id: '94', translation: 'aquafaba', spiritType: SpiritType.None },
+    { id: '94', translation: 'aquafaba', spiritType: SpiritType.None, replacementIds: ['23', '114']},
     // https://en.wikipedia.org/wiki/Aquafaba
     { id: '95', translation: 'mango', spiritType: SpiritType.None },
     { id: '96', translation: 'passoa', spiritType: SpiritType.None },

--- a/src/locales/en/instructions.json
+++ b/src/locales/en/instructions.json
@@ -1,7 +1,7 @@
 {
     "a-furlong-too-late": "Pour the rum and ginger beer into a highball glass almost filled with ice cubes. \nStir well. \nGarnish with a lemon twist.",
     "absolut-limousine": "Pour lemon vodka and lime juice into a glass. \nAdd Ice and fill with tonic water. \nGarnish with lime wedges.",
-    "after-dinner-cocktail": "Shake all ingredients (except lime wedge) with ice and strain into a cocktail glass. \nAdd the wedge of lime and serve.",
+    "after-dinner-cocktail": "Shake all ingredients with ice and strain into a cocktail glass. \nGarnish with a wedge of lime.",
     "afterglow": "Mix all ingredients together. \nServe over ice.",
     "alabama-slammer": "Pour all ingredients (except for lemon juice) over ice in a highball glass. \nStir, add a dash of lemon juice, and serve.",
     "alexander": "Shake all ingredients with ice and strain contents into a cocktail glass. \nSprinkle nutmeg on top and serve.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -188,5 +188,5 @@
     "paste-backup-content-title": "Paste Backup Content",
     "paste-backup-content": "Paste the content of your backup file here to restore it",
     "android-storage-limitations": "Due to Android 11 storage limitations, backups cannot be loaded if the app was reinstalled or backup was modified externally",
-    "general-substitutions-paragraph": "Alot of ingredients can almost always be substituted by other ingredients. Drinkable provides the following substitutes"
+    "general-substitutions-paragraph": "A lot of ingredients can almost always be substituted by other ingredients. Drinkable provides the following substitutes:"
 }


### PR DESCRIPTION
A few quick updates here.
- Updated after dinner cocktail recipe to align with other recipes - was supposed to be with previous pull request but was stashed change that was left out
- Corrected "alot" to "a lot" in introduction section of substitute ingredients page.
- Added aquafaba as substitute for egg white, and egg white as substitute for aquafaba as these generally serve the same purpose in cocktails.