### PR TITLE
chore: prepare v1.58.0 release for App Stores

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.moimob.drinkable"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 15703
-        versionName "1.57.3"
+        versionCode 15800
+        versionName "1.58.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/fastlane/metadata/android/en-US/changelogs/15800.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15800.txt
@@ -1,0 +1,3 @@
+• New: Navigation now shows "Mocktails" when you're viewing only mocktails
+• Improved: Page titles and messages now match your drink filter selection
+• Enhanced: App now shows both cocktails and mocktails by default


### PR DESCRIPTION
- Update version to 1.58.0 (versionCode 15800)
- Add user-friendly release notes for  App Stores

🤖 Generated with [Claude Code](https://claude.ai/code)