### PR TITLE
Use mise for toolchain, add copy-cocktail feature, desktop web layout

### DIFF
--- a/.github/workflows/build-verification-apk.yml
+++ b/.github/workflows/build-verification-apk.yml
@@ -10,16 +10,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Setup Java
-              uses: actions/setup-java@v4
-              with:
-                  distribution: 'zulu'
-                  java-version: '21'
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 22.x
+            - name: Setup mise
+              uses: jdx/mise-action@v2
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,8 @@ jobs:
               with:
                   usePlayStoreLocales: true
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 22.x
+            - name: Setup mise
+              uses: jdx/mise-action@v2
 
             - name: Install app dependencies
               run: npm ci

--- a/.github/workflows/fastlane-internal.yml
+++ b/.github/workflows/fastlane-internal.yml
@@ -16,16 +16,8 @@ jobs:
               with:
                   usePlayStoreLocales: true
 
-            - name: Setup Java
-              uses: actions/setup-java@v4
-              with:
-                distribution: temurin
-                java-version: '21.0.7'
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 22.x
+            - name: Setup mise
+              uses: jdx/mise-action@v2
 
             - name: Install app dependencies
               run: npm ci

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "22"
+java = "temurin-21"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 This project is bootstrapped by [aurelia-cli](https://github.com/aurelia/cli).
 For more information, go to https://aurelia.io/docs/cli/webpack
 
+### Toolchain
+
+Node and Java versions are pinned via [mise](https://mise.jdx.dev/). Install mise, then run `mise install` in the repo root to get the correct versions.
+
 ### Run dev app
 
 Run `npm start`, then open `http://localhost:8080`
@@ -76,7 +80,7 @@ Locate `src/data/ingredient-data.ts`
 
 Add ingredient to the end of the list. Example:
 
-```json
+```ts
 { id: '165', translation: 'chocolate-sauce', spiritType: SpiritType.None }
 ```
 
@@ -100,7 +104,7 @@ Locate `src/data/cocktail-data.ts`
 
 Add cocktail to the end of the list. Example
 
-```json
+```ts
 {
     id: '191',
     imageSrc: 'images/salted_toffee_martini.jpg',
@@ -186,7 +190,7 @@ Locate `src/data/languages.ts`
 
 Add your language to this array.
 
-```
+```ts
 const languages = [
     { value: undefined, name: 'English' },
     { value: 'de', name: 'Deutsch' },

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.moimob.drinkable"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 15902
-        versionName "1.59.2"
+        versionCode 15903
+        versionName "1.59.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/cypress/e2e/cocktails.cy.ts
+++ b/cypress/e2e/cocktails.cy.ts
@@ -131,6 +131,64 @@ describe('Cocktails', () => {
         });
     });
 
+    describe('Duplicate', () => {
+        it('From long-press menu - Should open pre-filled copy in edit mode', () => {
+            cy.visit('#/cocktails');
+
+            cy.dataCy('cocktails-wrapper')
+                .children()
+                .first()
+                .invoke('text')
+                .then(originalName => {
+                    cy.dataCy('cocktails-wrapper')
+                        .children()
+                        .first()
+                        .then(el => el[0].dispatchEvent(new Event('long-press')));
+
+                    cy.dataCy('manage-cocktail-row-dialog').should('be.visible');
+                    cy.dataCy('create-cocktail-from-button').click();
+
+                    cy.dataCy('cocktail-name-input')
+                        .invoke('val')
+                        .should('eq', `${originalName.trim()} (copy)`);
+
+                    cy.dataCy('amount-input').first().invoke('val').should('not.be.empty');
+                    cy.dataCy('textarea').invoke('val').should('not.be.empty');
+
+                    cy.dataCy('save-cocktail').click();
+
+                    cy.dataCy('cocktail-dialog').should('contain', `${originalName.trim()} (copy)`);
+
+                    cy.dataCy('close-dialog').click();
+
+                    cy.dataCy('cocktails-wrapper').should('contain', `${originalName.trim()} (copy)`);
+                });
+        });
+
+        it('From cocktail dialog menu - Should open pre-filled copy in edit mode', () => {
+            cy.visit('#/cocktails');
+
+            cy.dataCy('cocktails-wrapper')
+                .children()
+                .first()
+                .invoke('text')
+                .then(originalName => {
+                    cy.dataCy('cocktails-wrapper').children().first().click();
+
+                    cy.dataCy('cocktail-dialog-dropdown').find('summary').click();
+                    cy.dataCy('dropdown-create-cocktail-from').click();
+
+                    cy.dataCy('cocktail-name-input')
+                        .invoke('val')
+                        .should('eq', `${originalName.trim()} (copy)`);
+
+                    cy.dataCy('save-cocktail').click();
+
+                    cy.dataCy('cocktail-dialog').should('contain', `${originalName.trim()} (copy)`);
+                });
+        });
+    });
+
     describe('From Ingredients', () => {
         it('Empty list - Should display text', () => {
             cy.visit('#/cocktails');

--- a/fastlane/metadata/android/en-US/changelogs/15903.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15903.txt
@@ -1,0 +1,2 @@
+• New: Long-press a cocktail to duplicate it into a new recipe
+• Improved: Better layout on wider screens

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
         "lint-fix": "eslint --fix --ext .ts ."
     },
     "engines": {
-        "node": ">=20.11.0"
+        "node": ">=22"
     }
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,6 +1,8 @@
 <template>
     <require from="./components/toast/toast-container"></require>
     <navbar router.bind="router" hidden.bind="navbarHidden"></navbar>
-    <router-view></router-view>
+    <div id="app-content">
+        <router-view></router-view>
+    </div>
     <toast-container></toast-container>
 </template>

--- a/src/components/dialogs/cocktail-dialog/cocktail-dialog.html
+++ b/src/components/dialogs/cocktail-dialog/cocktail-dialog.html
@@ -1,5 +1,5 @@
 <template>
-    <ux-dialog class="au-animate cocktail-dialog bg-base-100" data-cy="cocktail-dialog">
+    <ux-dialog class="au-animate cocktail-dialog cocktail-detail-dialog bg-base-100" data-cy="cocktail-dialog">
         <header class="bg-base-300 h-12 w-full z-10 flex items-center p-2">
             <icon-arrow-back
                 click.trigger="controller.cancel()"
@@ -41,6 +41,12 @@
                         <a click.delegate="restoreCocktail()">
                             <icon-refresh-outline class="h-5 w-5"></icon-refresh-outline>
                             <p t="restore-cocktail"></p>
+                        </a>
+                    </li>
+                    <li data-cy="dropdown-create-cocktail-from">
+                        <a click.delegate="createCocktailFrom()">
+                            <icon-clipboard class="h-5 w-5"></icon-clipboard>
+                            <p t="create-cocktail-from"></p>
                         </a>
                     </li>
                     <li data-cy="dropdown-toggle-favorite">

--- a/src/components/dialogs/cocktail-dialog/cocktail-dialog.ts
+++ b/src/components/dialogs/cocktail-dialog/cocktail-dialog.ts
@@ -109,8 +109,8 @@ export class CocktailDialog {
     }
 
     activate(cocktail: Cocktail) {
-        if (cocktail === null) {
-            this.cocktail = new Cocktail();
+        if (cocktail === null || cocktail.id === undefined) {
+            this.cocktail = cocktail ?? new Cocktail();
             this.isEditMode = true;
             this.isNewCocktail = true;
         } else {
@@ -313,6 +313,13 @@ export class CocktailDialog {
 
             this.cocktail = await this._cocktailService.updateCocktailInformationByRequest(updateRequest);
         }
+    }
+
+    createCocktailFrom() {
+        this.closeDetailsElement();
+
+        const copy = this._cocktailService.createCocktailCopy(this.cocktail);
+        this._dialogService.open({ viewModel: CocktailDialog, model: copy, lock: false });
     }
 
     editCocktail() {

--- a/src/dialog.scss
+++ b/src/dialog.scss
@@ -5,6 +5,8 @@ ux-dialog-container {
     transition: opacity 0.2s linear;
     background: hsl(0deg 0% 25% / 90%);
     position: fixed;
+    height: 100vh;
+    height: 100dvh;
     &.active {
         opacity: 1;
     }
@@ -172,5 +174,27 @@ ux-dialog {
         top: 50%;
         transform: translate(-50%, -50%);
         width: 100%;
+    }
+}
+
+// Desktop / website layout
+// Only the main cocktail detail/edit dialog gets a capped, centered "card" treatment,
+// applied via `position: fixed` so it's fully decoupled from its wrapper's layout.
+// Other dialogs (filter, drawers, small action sheets) rely on filling the full
+// ux-dialog box (some position children with `fixed`/`absolute` against the viewport),
+// so they're left at their native full-size behavior and stay untouched here.
+@media (min-width: 768px) {
+    ux-dialog.cocktail-detail-dialog {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 680px;
+        max-width: 90vw;
+        height: 85dvh;
+        max-height: 850px;
+        border-radius: 1em;
+        overflow: hidden;
+        box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
     }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -189,6 +189,8 @@
     "restore-cocktail": "Restore Cocktail",
     "base-cocktail-is-edited": "You have modified this recipe",
     "cocktail-deleted": "Cocktail {{name}} was removed",
+    "create-cocktail-from": "Create Cocktail From This",
+    "cocktail-copy-name": "{{name}} (copy)",
     "create": "Create",
     "last-modified": "Last Modified",
     "restore-backup": "Restore Backup",

--- a/src/main.scss
+++ b/src/main.scss
@@ -542,3 +542,33 @@ body {
 .btm-nav > :where(.active) {
     @apply bg-base-300;
 }
+
+// Desktop / website layout
+@media (min-width: 1024px) {
+    #app-content {
+        position: relative;
+        height: 100dvh;
+    }
+
+    .cocktail-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        align-content: start;
+        gap: 0.5em;
+        padding: 0 0.5em;
+    }
+
+    .cocktail-grid > .cocktail-list-item {
+        border-radius: var(--widget-border-radius, 0.75em);
+        background: hsl(var(--b2));
+        padding: 0.5em 0.75em;
+        transition:
+            transform 0.15s ease,
+            box-shadow 0.15s ease;
+    }
+
+    .cocktail-grid > .cocktail-list-item:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+    }
+}

--- a/src/modules/cocktails/all-cocktails/all-cocktails.html
+++ b/src/modules/cocktails/all-cocktails/all-cocktails.html
@@ -1,6 +1,6 @@
 <template>
     <require from="./../cocktail-filter-component"></require>
-    <div class="absolute h-full w-full overflow-y-scroll pb-12" data-cy="cocktails-wrapper">
+    <div class="absolute h-full w-full overflow-y-scroll pb-12 cocktail-grid" data-cy="cocktails-wrapper">
         <cocktail-list-item
             repeat.for="cocktail of filteredCocktails"
             click.delegate="openCocktailDialog(cocktail)"

--- a/src/modules/cocktails/all-cocktails/all-cocktails.ts
+++ b/src/modules/cocktails/all-cocktails/all-cocktails.ts
@@ -102,8 +102,14 @@ export class AllCocktails {
     openCocktailRowDialog(cocktail: Cocktail) {
         this._dialogService
             .open({ viewModel: ManageCocktailRowDialog, model: cocktail, lock: false })
-            .whenClosed(() => {
+            .whenClosed(response => {
                 this.params.filter = undefined;
+
+                if (response.output?.action === 'duplicate') {
+                    this.openCocktailDialog(response.output.cocktail);
+                    return;
+                }
+
                 this.bind();
             });
     }

--- a/src/modules/cocktails/dialogs/manage-cocktail-row-dialog.html
+++ b/src/modules/cocktails/dialogs/manage-cocktail-row-dialog.html
@@ -15,6 +15,11 @@
                         class="h-6 w-6 ${cocktail.isFavorite ? 'text-error fill-error' : 'fill-none'}"></icon-heart>
                 </button>
 
+                <button click.delegate="createCocktailFrom()" class="btn w-full mt-2" data-cy="create-cocktail-from-button">
+                    <p t="create-cocktail-from"></p>
+                    <icon-clipboard class="h-6 w-6"></icon-clipboard>
+                </button>
+
                 <copy-to-clipboard class="mt-4" name.bind="cocktail.name"></copy-to-clipboard>
             </div>
         </div>

--- a/src/modules/cocktails/dialogs/manage-cocktail-row-dialog.ts
+++ b/src/modules/cocktails/dialogs/manage-cocktail-row-dialog.ts
@@ -25,6 +25,11 @@ export class ManageCocktailRowDialog {
         this.dialogController.cancel();
     }
 
+    createCocktailFrom() {
+        const copy = this.cocktailService.createCocktailCopy(this.cocktail);
+        this.dialogController.ok({ action: 'duplicate', cocktail: copy });
+    }
+
     async toggleIsFavorite() {
         this.cocktail.isFavorite = !this.cocktail.isFavorite;
 

--- a/src/modules/cocktails/from-ingredients/from-ingredients.html
+++ b/src/modules/cocktails/from-ingredients/from-ingredients.html
@@ -2,13 +2,15 @@
     <require from="./../cocktail-filter-component"></require>
     <div class="absolute h-full w-full overflow-y-scroll pb-12">
         <div if.bind="cocktails.length > 0 || cocktailsWithMissingIngredient.length > 0" class="mt-1">
-            <cocktail-list-item
-                repeat.for="cocktail of cocktails"
-                click.delegate="openCocktailDialog($event, cocktail)"
-                id="from-ingredients-cocktails-${cocktail.id}"
-                data-long-press-delay="600"
-                cocktail.bind="cocktail">
-            </cocktail-list-item>
+            <div class="cocktail-grid">
+                <cocktail-list-item
+                    repeat.for="cocktail of cocktails"
+                    click.delegate="openCocktailDialog($event, cocktail)"
+                    id="from-ingredients-cocktails-${cocktail.id}"
+                    data-long-press-delay="600"
+                    cocktail.bind="cocktail">
+                </cocktail-list-item>
+            </div>
 
             <div click.delegate="toggleIsOpen()" class="collapse collapse-arrow bg-base-200 rounded-none my-4">
                 <input type="checkbox" checked.bind="isOpen" class="hidden" />
@@ -16,11 +18,13 @@
                     <p t="one-missing-ingredients"></p>
                 </div>
                 <div class="collapse-content px-0">
-                    <cocktail-list-item
-                        repeat.for="cocktail of cocktailsWithMissingIngredient"
-                        click.delegate="openCocktailDialog($event, cocktail)"
-                        cocktail.bind="cocktail">
-                    </cocktail-list-item>
+                    <div class="cocktail-grid">
+                        <cocktail-list-item
+                            repeat.for="cocktail of cocktailsWithMissingIngredient"
+                            click.delegate="openCocktailDialog($event, cocktail)"
+                            cocktail.bind="cocktail">
+                        </cocktail-list-item>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/modules/cocktails/from-ingredients/from-ingredients.ts
+++ b/src/modules/cocktails/from-ingredients/from-ingredients.ts
@@ -114,7 +114,16 @@ export class FromIngredients {
         event?.stopPropagation();
         this._dialogService
             .open({ viewModel: ManageCocktailRowDialog, model: cocktail, lock: false })
-            .whenClosed(() => {
+            .whenClosed(response => {
+                if (response.output?.action === 'duplicate') {
+                    this._dialogService
+                        .open({ viewModel: CocktailDialog, model: response.output.cocktail, lock: false })
+                        .whenClosed(() => {
+                            this.bind();
+                        });
+                    return;
+                }
+
                 this.bind();
             });
     }

--- a/src/modules/user/cocktails/user-cocktails.html
+++ b/src/modules/user/cocktails/user-cocktails.html
@@ -4,10 +4,12 @@
             <button click.delegate="openDialog(null)" class="btn btn-secondary" t="add" data-cy="add-cocktail"></button>
         </div>
 
-        <cocktail-list-item
-            repeat.for="cocktail of cocktails"
-            click.delegate="openDialog(cocktail)"
-            cocktail.bind="cocktail">
-        </cocktail-list-item>
+        <div class="cocktail-grid">
+            <cocktail-list-item
+                repeat.for="cocktail of cocktails"
+                click.delegate="openDialog(cocktail)"
+                cocktail.bind="cocktail">
+            </cocktail-list-item>
+        </div>
     </div>
 </template>

--- a/src/services/cocktail-service.ts
+++ b/src/services/cocktail-service.ts
@@ -200,6 +200,20 @@ export class CocktailService {
         return cocktail;
     }
 
+    public createCocktailCopy(cocktail: Cocktail): Cocktail {
+        const copy = new Cocktail();
+        copy.name = this.i18n.tr('cocktail-copy-name', { name: cocktail.name });
+        copy.category = cocktail.category;
+        copy.imageSrc = cocktail.imageSrc;
+        copy.isImagePortrait = cocktail.isImagePortrait;
+        copy.ingredientGroups = cocktail.ingredientGroups.map(x => ({ ...x }));
+        copy.tags = [...(cocktail.tags ?? [])];
+        copy.instructions =
+            cocktail.instructions ??
+            (cocktail.translation ? this.i18n.tr(cocktail.translation, { ns: 'instructions' }) : undefined);
+        return copy;
+    }
+
     public async restoreCocktail(cocktail: Cocktail): Promise<Cocktail> {
         this._cocktailInformation = this._cocktailInformation.filter(x => x.id !== cocktail.id);
         this._cocktailInformation.push({


### PR DESCRIPTION
## Summary
- Pin Node/Java versions via mise (`.mise.toml`); CI, build-verification, and fastlane workflows now install via `jdx/mise-action` instead of separate `setup-node`/`setup-java` steps.
- Add "Create Cocktail From This" to duplicate an existing cocktail into the add-cocktail form (fully pre-filled: ingredients, tags, instructions), available from the long-press row menu and the cocktail detail dialog's menu (view mode only).
- Fixed a bug found while testing: `CocktailDialog.activate()` only entered edit/new mode when the passed-in model was `null`, so a duplicated cocktail (real object, `id` undefined) opened read-only and would've thrown on save.
- Desktop (>=1024px) layout: full-width content, multi-column cocktail grid, capped/centered cocktail detail dialog. Other dialogs (filter, drawers) are left untouched since they rely on filling the full viewport (position:fixed action bars etc).
- Fixed a backdrop/click-through bug: centering the detail dialog via `position: fixed` removed it from the flow that gave the dialog backdrop its height, collapsing the backdrop to zero size — which also let clicks pass through to cards underneath and stack multiple dialogs open at once. Fixed by giving the backdrop container an explicit height.
- Fixed README code fences mislabeled as `json` when the content is actually TypeScript object literals.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [x] Manually verified in Chrome at desktop width (1440px): full-width grid, centered cocktail dialog with visible backdrop, filter dialog and shopping-list drawer unaffected, duplicate-cocktail flow end-to-end (both entry points) including save
- [ ] Manual check on an actual mobile viewport/device (couldn't resize the browser window in this environment to verify pixel-for-pixel, but all desktop CSS is `min-width`-gated so mobile styles are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)