### PR TITLE
Add ingredient substitutions management and shopping list home widget

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.moimob.drinkable"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 15903
-        versionName "1.59.3"
+        versionCode 16000
+        versionName "1.60.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/cypress/e2e/ingredient-substitutions.cy.ts
+++ b/cypress/e2e/ingredient-substitutions.cy.ts
@@ -1,0 +1,82 @@
+describe('Ingredient Substitutions', () => {
+    beforeEach(() => {
+        window.localStorage.setItem('CapacitorStorage.messuarement-system', 'Metric');
+    });
+
+    it('Add custom substitution', () => {
+        cy.visit('#/user');
+        cy.dataCy('menu-ingredient-substitutions').click();
+
+        cy.dataCy('no-user-substitutions').should('be.visible');
+
+        cy.dataCy('add-substitution').click();
+
+        cy.dataCy('substitution-source-select').select('Vodka');
+
+        // Save must stay disabled until at least one substitute is picked - regression guard
+        cy.dataCy('save-substitution').should('be.disabled');
+
+        cy.dataCy('substitution-replacement-checkbox-6').check();
+        cy.dataCy('substitution-note-input').type('Great in a Vesper');
+
+        cy.dataCy('save-substitution').should('not.be.disabled').click();
+
+        cy.dataCy('no-user-substitutions').should('not.exist');
+        cy.dataCy('substitution-row-8')
+            .should('contain.text', 'Vodka')
+            .should('contain.text', 'Gin')
+            .should('contain.text', 'Great in a Vesper');
+    });
+
+    it('Edit custom substitution', () => {
+        window.localStorage.setItem(
+            'CapacitorStorage.user-substitutions',
+            JSON.stringify([{ ingredientId: '8', replacementIds: ['6'], note: 'Original note' }])
+        );
+
+        cy.visit('#/user');
+        cy.dataCy('menu-ingredient-substitutions').click();
+
+        cy.dataCy('substitution-row-8').should('contain.text', 'Original note');
+
+        cy.dataCy('edit-substitution-8').click();
+
+        cy.dataCy('substitution-source-select').should('be.disabled').find(':selected').should('contain.text', 'Vodka');
+        cy.dataCy('substitution-replacement-checkbox-6').should('be.checked');
+
+        cy.dataCy('substitution-note-input').clear();
+        cy.dataCy('substitution-note-input').type('Updated note');
+        cy.dataCy('save-substitution').click();
+
+        cy.dataCy('substitution-row-8').should('contain.text', 'Updated note');
+    });
+
+    it('Delete custom substitution', () => {
+        window.localStorage.setItem(
+            'CapacitorStorage.user-substitutions',
+            JSON.stringify([{ ingredientId: '8', replacementIds: ['6'] }])
+        );
+
+        cy.visit('#/user');
+        cy.dataCy('menu-ingredient-substitutions').click();
+
+        cy.dataCy('substitution-row-8').should('be.visible');
+
+        cy.dataCy('edit-substitution-8').click();
+        cy.dataCy('delete-substitution').click();
+
+        cy.dataCy('substitution-row-8').should('not.exist');
+        cy.dataCy('no-user-substitutions').should('be.visible');
+    });
+
+    it('Built-in substitutions are read-only', () => {
+        cy.visit('#/user');
+        cy.dataCy('menu-ingredient-substitutions').click();
+
+        cy.dataCy('default-substitutions').click();
+
+        // Ingredient '2' (lime-juice) ships with a built in substitute
+        cy.dataCy('default-substitution-row-2').should('contain.text', 'Lime');
+        cy.dataCy('default-substitution-row-2').find('button').should('not.exist');
+    });
+});

--- a/cypress/e2e/ingredients.cy.ts
+++ b/cypress/e2e/ingredients.cy.ts
@@ -4,22 +4,26 @@ describe('Ingredients', () => {
         cy.visit('#/ingredients');
 
         cy.dataCy('selected-bar-component').should('not.exist');
-        cy.dataCy('ingredient-list').find('div').should('have.length', 0);
+        cy.dataCy('ingredient-list').find('.ingredient-group-item').should('have.length', 0);
         cy.dataCy('add-ingredients-search').type('Vodka');
         cy.dataCy('tag-vodka').click();
         cy.dataCy('close-x-button').click();
 
-        cy.dataCy('ingredient-list').find('div').should('have.length', 1).first().should('contain', 'Vodka');
+        cy.dataCy('ingredient-list')
+            .find('.ingredient-group-item')
+            .should('have.length', 1)
+            .first()
+            .should('contain', 'Vodka');
 
         cy.dataCy('remove-vodka').click();
 
-        cy.dataCy('ingredient-list').find('div').should('have.length', 0);
+        cy.dataCy('ingredient-list').find('.ingredient-group-item').should('have.length', 0);
     });
 
     it('My Inventory, Navigate to "All Ingredients" to Add', () => {
         window.localStorage.setItem('CapacitorStorage.messuarement-system', 'Metric');
         cy.visit('#/ingredients');
-        cy.dataCy('ingredient-list').find('div').should('have.length', 0);
+        cy.dataCy('ingredient-list').find('.ingredient-group-item').should('have.length', 0);
 
         navigateToAllIngredients();
 
@@ -27,7 +31,11 @@ describe('Ingredients', () => {
 
         navigateToInventory();
 
-        cy.dataCy('ingredient-list').find('div').should('have.length', 1).first().should('contain', 'Vodka');
+        cy.dataCy('ingredient-list')
+            .find('.ingredient-group-item')
+            .should('have.length', 1)
+            .first()
+            .should('contain', 'Vodka');
     });
 
     it('My Inventory, Add All ingredients', () => {

--- a/fastlane/metadata/android/en-US/changelogs/16000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16000.txt
@@ -1,0 +1,4 @@
+• New: Add your own ingredient substitutions, with an optional note
+• New: Shopping list widget on the home screen shows what you still need to buy
+• Improved: Tap a substitute ingredient in a recipe to jump straight to it in My Substitutions
+• Improved: Built-in substitutions are now kept separate from your own in My Substitutions

--- a/src/components/dialogs/cocktail-dialog/cocktail-dialog.html
+++ b/src/components/dialogs/cocktail-dialog/cocktail-dialog.html
@@ -267,7 +267,10 @@
                                 <span else>${ingredientGroup.ingredient.name}</span>
                             </h5>
 
-                            <h6 if.bind="ingredientGroup.substituteNames" class="text-sm opacity-75">
+                            <h6
+                                if.bind="ingredientGroup.substituteNames"
+                                class="text-sm opacity-75"
+                                data-cy="ingredient-substitutes-text">
                                 <span>(</span><span t="or"></span>
                                 <span>${ingredientGroup.substituteNames})</span>
                             </h6>

--- a/src/components/dialogs/cocktail-dialog/cocktail-dialog.ts
+++ b/src/components/dialogs/cocktail-dialog/cocktail-dialog.ts
@@ -20,6 +20,7 @@ import { isEqual } from 'functions/utils';
 import { AmountFormatValueConverter } from 'converters/amount-format';
 import { ToastService } from 'components/toast/toast-service';
 import { I18N } from 'aurelia-i18n';
+import { Router } from 'aurelia-router';
 @inject(
     DialogController,
     LocalStorageService,
@@ -29,7 +30,8 @@ import { I18N } from 'aurelia-i18n';
     DialogService,
     AmountFormatValueConverter,
     ToastService,
-    I18N
+    I18N,
+    Router
 )
 export class CocktailDialog {
     @observable public searchFilter: string;
@@ -74,7 +76,8 @@ export class CocktailDialog {
         private _dialogService: DialogService,
         private _amountFormat: AmountFormatValueConverter,
         private _toastService: ToastService,
-        private _i18n: I18N
+        private _i18n: I18N,
+        private _router: Router
     ) {
         this.controller = dialogContoller;
         this.handleInputBlur = () => {
@@ -263,9 +266,16 @@ export class CocktailDialog {
 
     longClick(group: ExtendedIngredientGroup) {
         this._dialogService.open({ viewModel: ManageIngredientRow, model: group, lock: false }).whenClosed(response => {
-            if (!response.wasCancelled) {
-                group.isInStorage = response.output.isInStorage;
+            if (response.wasCancelled) {
+                return;
             }
+
+            if (response.output.navigateToSubstitutions) {
+                this.navigateToSubstitutions(group.ingredient);
+                return;
+            }
+
+            group.isInStorage = response.output.isInStorage;
         });
     }
 
@@ -386,6 +396,11 @@ export class CocktailDialog {
         event.stopPropagation();
         const cocktail = this._cocktailService.getCocktailById(ingredient.recipeId);
         this._dialogService.open({ viewModel: CocktailDialog, model: cocktail, lock: false });
+    }
+
+    navigateToSubstitutions(ingredient: Ingredient) {
+        this.controller.cancel();
+        this._router.navigate(`/user/ingredient-substitutions?ingredientId=${ingredient.id}`);
     }
 
     async createOrUpdateCocktail() {

--- a/src/components/dialogs/cocktail-dialog/manage-ingredient-row.html
+++ b/src/components/dialogs/cocktail-dialog/manage-ingredient-row.html
@@ -16,6 +16,13 @@
                     <p else t="add-to-bar"></p>
                 </button>
 
+                <button
+                    if.bind="substituteNames"
+                    click.delegate="navigateToSubstitutions()"
+                    class="btn w-full mt-2"
+                    t="substitutes"
+                    data-cy="navigate-to-substitutions-button"></button>
+
                 <copy-to-clipboard class="mt-4" name.bind="name"></copy-to-clipboard>
             </div>
         </div>

--- a/src/components/dialogs/cocktail-dialog/manage-ingredient-row.ts
+++ b/src/components/dialogs/cocktail-dialog/manage-ingredient-row.ts
@@ -14,6 +14,7 @@ export class ManageIngredientRow {
     public isInStorage: boolean;
     public selectedBarName: string;
     public showBarName: boolean;
+    public substituteNames: string;
 
     private _ingredientId: string;
     private _savedIngredientIds: string[] = [];
@@ -21,6 +22,7 @@ export class ManageIngredientRow {
     activate(params: ExtendedIngredientGroup) {
         this.isInStorage = params.isInStorage;
         this.name = params.ingredient.name;
+        this.substituteNames = params.substituteNames;
 
         const selectedBar = this.localStorageService.getIngredientList();
         this.selectedBarName = selectedBar.name;
@@ -52,8 +54,18 @@ export class ManageIngredientRow {
 
         this.dialogController.ok(response);
     }
+
+    navigateToSubstitutions() {
+        const response: ManageIngredientRowResponse = {
+            isInStorage: this.isInStorage,
+            navigateToSubstitutions: true
+        };
+
+        this.dialogController.ok(response);
+    }
 }
 
 export type ManageIngredientRowResponse = {
     isInStorage: boolean;
+    navigateToSubstitutions?: boolean;
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ export function configure(config: FrameworkConfiguration) {
         PLATFORM.moduleName('./widgets/add-ingredients/add-ingredients'),
         PLATFORM.moduleName('./widgets/navigation-widget/navigation-widget'),
         PLATFORM.moduleName('./widgets/season-explore/season-explore'),
+        PLATFORM.moduleName('./widgets/shopping-list-widget/shopping-list-widget'),
         PLATFORM.moduleName('./navbar/navbar'),
         PLATFORM.moduleName('./cocktail-list-item.html'),
         PLATFORM.moduleName('./../converters/amount-format'),

--- a/src/components/toast/toast-container.html
+++ b/src/components/toast/toast-container.html
@@ -1,6 +1,9 @@
 <template>
-    <div class="toast toast-center z-50" data-cy="toast-container">
-        <div repeat.for="toast of toasts" id.bind="toast.id" class="alert flex justify-between ${toast.className}">
+    <div class="toast toast-center z-50 pointer-events-none" data-cy="toast-container">
+        <div
+            repeat.for="toast of toasts"
+            id.bind="toast.id"
+            class="alert flex justify-between pointer-events-auto ${toast.className}">
             <span>${toast.text}</span>
             <icon-close click.delegate="removeToast(toast)" class="w-5 h-5 opacity-75"></icon-close>
         </div>

--- a/src/components/widgets/shopping-list-widget/shopping-list-widget.html
+++ b/src/components/widgets/shopping-list-widget/shopping-list-widget.html
@@ -1,0 +1,40 @@
+<template>
+    <div class="mx-4 mt-4">
+        <div
+            click.delegate="navigateToShoppingLists()"
+            class="card card-compact w-full bg-base-200 shadow-xl overflow-hidden"
+            data-cy="shopping-list-widget">
+            <div class="card-body">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h5
+                            class="font-bold text-base"
+                            t="shopping-list.list"
+                            data-cy="shopping-list-widget-title"></h5>
+                        <p
+                            class="text-xs"
+                            t="shopping-list.widget-subtitle"
+                            data-cy="shopping-list-widget-subtitle"></p>
+                    </div>
+                    <icon-arrow-forward class="h-8 w-8"></icon-arrow-forward>
+                </div>
+
+                <div show.bind="shoppingListItems.length > 0" class="mt-2">
+                    <div
+                        repeat.for="item of shoppingListItems"
+                        class="bg-base-100 rounded p-2 mb-2"
+                        data-cy="shopping-list-widget-item">
+                        <p class="font-semibold text-sm mb-1">${item.list.name}</p>
+                        <p class="text-xs opacity-75">${item.itemsToBuy.join(', ')}</p>
+                    </div>
+                </div>
+
+                <p
+                    show.bind="shoppingListItems.length === 0"
+                    class="text-xs opacity-60 mt-2"
+                    t="shopping-list.widget-empty"
+                    data-cy="shopping-list-widget-empty"></p>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/components/widgets/shopping-list-widget/shopping-list-widget.ts
+++ b/src/components/widgets/shopping-list-widget/shopping-list-widget.ts
@@ -1,0 +1,38 @@
+import { autoinject } from 'aurelia-framework';
+import { Router } from 'aurelia-router';
+import { LocalStorageService } from 'services/local-storage-service';
+import { IngredientService } from 'services/ingredient-service';
+import { ShoppingList } from 'modules/user/shopping-list/shopping-list-models';
+
+@autoinject
+export class ShoppingListWidget {
+    public shoppingListItems: ShoppingListWidgetItem[] = [];
+
+    constructor(
+        private _router: Router,
+        private _localStorageService: LocalStorageService,
+        private _ingredientService: IngredientService
+    ) {}
+
+    bind() {
+        this.shoppingListItems = this._localStorageService
+            .getShoppingLists()
+            .map(list => ({
+                list,
+                itemsToBuy: list.ingredients
+                    .filter(x => !x.shopped)
+                    .map(x => this._ingredientService.getIngredientById(x.id)?.name)
+                    .filter(name => name !== undefined)
+            }))
+            .filter(x => x.itemsToBuy.length > 0);
+    }
+
+    navigateToShoppingLists() {
+        this._router.navigate('#/user/shopping-lists');
+    }
+}
+
+type ShoppingListWidgetItem = {
+    list: ShoppingList;
+    itemsToBuy: string[];
+};

--- a/src/domain/entities/ingredient.ts
+++ b/src/domain/entities/ingredient.ts
@@ -19,6 +19,14 @@ export class ManageIngredientModel extends Ingredient {
 
 export type IngredientSubstitutionModel = Ingredient & {
     substitutions: string[];
+    note?: string;
+    isUserDefined: boolean;
+};
+
+export type UserSubstitution = {
+    ingredientId: string;
+    replacementIds: string[];
+    note?: string;
 };
 
 export class CreatedIngredientModel extends Ingredient {

--- a/src/domain/enums/widget.ts
+++ b/src/domain/enums/widget.ts
@@ -3,5 +3,6 @@ export enum Widget {
     IngredientWidget = 1,
     AddIngredients = 2,
     Navigation = 3,
-    SeasonalCocktails = 4
+    SeasonalCocktails = 4,
+    ShoppingList = 5
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -25,6 +25,11 @@
     "one-missing-ingredients": "1 Missing Ingredient",
     "created-ingredients": "Created Ingredients",
     "add": "Add",
+    "add-ingredient": "Add ingredient",
+    "add-ingredient-list": "Add ingredient list",
+    "add-shopping-list": "Add shopping list",
+    "add-cocktail": "Add cocktail",
+    "add-tag": "Add tag",
     "used-in-cocktails": "Used in {{usedInCocktailNames.length}} cocktails",
     "used-in-cocktail": "Used in {{usedInCocktailNames}}",
     "add-ingredients": "Add Ingredients",
@@ -143,7 +148,7 @@
         "edit-ingredient-list": "Edit Bar",
         "backups-title": "My Backups",
         "backups-subtitle": "Manage backups",
-        "ingredient-substitutions-title": "Common Ingredient Substitutions",
+        "ingredient-substitutions-title": "My Substitutions",
         "ingredient-substitutions-subtitle": "Ingredient Substitutions used in Drinkable"
     },
     "alcohol-level": {
@@ -171,7 +176,9 @@
         "edit-name": "Edit Name",
         "delete": "Delete",
         "ingredients": "ingredients",
-        "to-shop-on-date": "To Shop on {{date}}"
+        "to-shop-on-date": "To Shop on {{date}}",
+        "widget-subtitle": "Items you need to buy",
+        "widget-empty": "Nothing to buy right now"
     },
     "new": "New",
     "halloween-title": "Halloween!",
@@ -201,5 +208,12 @@
     "paste-backup-content-title": "Paste Backup Content",
     "paste-backup-content": "Paste the content of your backup file here to restore it",
     "android-storage-limitations": "Due to Android 11 storage limitations, backups cannot be loaded if the app was reinstalled or backup was modified externally",
-    "general-substitutions-paragraph": "A lot of ingredients can almost always be substituted by other ingredients. Drinkable provides the following substitutes:"
+    "general-substitutions-paragraph": "A lot of ingredients can almost always be substituted by other ingredients. Drinkable provides the following substitutes:",
+    "add-substitution": "Add substitution",
+    "edit-substitution": "Edit substitution",
+    "substitutes": "Substitutes",
+    "substitution-note": "Note",
+    "substitution-ingredient-locked-hint": "Can't be changed here — delete this and add a new one instead.",
+    "no-user-substitutions": "You haven't added any substitutions yet.",
+    "default-substitutions": "Built-in substitutions"
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -543,11 +543,16 @@ body {
     @apply bg-base-300;
 }
 
+:root {
+    --sidebar-width: 240px;
+}
+
 // Desktop / website layout
 @media (min-width: 1024px) {
     #app-content {
         position: relative;
         height: 100dvh;
+        margin-left: var(--sidebar-width);
     }
 
     .cocktail-grid {
@@ -570,5 +575,78 @@ body {
     .cocktail-grid > .cocktail-list-item:hover {
         transform: translateY(-2px);
         box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+    }
+
+    .ingredient-group-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+        gap: 0.25em 1em;
+    }
+
+    // Keep space-between so the checkmark/delete icon lands on the same edge
+    // in every row, aligning vertically down each grid column. Truncate the
+    // label instead of letting long names push the icon out or overflow.
+    .ingredient-group-list > .ingredient-group-item {
+        gap: 0.5em;
+    }
+
+    .ingredient-group-list > .ingredient-group-item > p {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .ingredient-group-list > .ingredient-group-item > svg {
+        flex-shrink: 0;
+    }
+
+    .ingredient-group-list > .ingredient-group-item:last-of-type {
+        border-bottom: none;
+    }
+
+    .full-page-height {
+        height: calc(100% - (4.25em + var(--top-safe-area)));
+    }
+
+    .page-content {
+        padding-bottom: 1em;
+    }
+
+    .home-header,
+    .user-header {
+        left: var(--sidebar-width);
+        width: calc(100% - var(--sidebar-width));
+    }
+
+    // Bottom tab bar becomes a left sidebar
+    .btm-nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        bottom: auto;
+        right: auto;
+        height: 100dvh;
+        width: var(--sidebar-width);
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: flex-start;
+        gap: 0.25rem;
+        padding: 1.5em 0.75em;
+        border-right: 1px solid hsl(var(--b3));
+    }
+
+    .btm-nav > * {
+        flex-basis: auto;
+        height: auto;
+        flex-direction: row;
+        justify-content: flex-start;
+        gap: 0.75em;
+        border-radius: var(--widget-border-radius, 0.75em);
+        padding: 0.65em 0.9em;
+    }
+
+    .btm-nav .btm-nav-label {
+        font-size: 0.875rem;
     }
 }

--- a/src/modules/cocktails/cocktails.html
+++ b/src/modules/cocktails/cocktails.html
@@ -3,14 +3,17 @@
     <require from="./from-ingredients/from-ingredients"></require>
 
     <header class="bg-base-300">
-        <h4 class="px-2 mb-1 pt-2" data-cy="cocktails-page-title" t.bind="currentDrinkTypeFilter === 2 ? 'routes.mocktails' : 'routes.cocktails'"></h4>
-        <div class="tabs tabs-lifted overflow-x-scroll hide-scrollbar flex-nowrap">
+        <h4
+            class="px-2 mb-1 pt-2"
+            t.bind="currentDrinkTypeFilter === 2 ? 'routes.mocktails' : 'routes.cocktails'"
+            data-cy="cocktails-page-title"></h4>
+        <div class="tabs tabs-lifted overflow-x-scroll hide-scrollbar flex-nowrap w-full">
             <a
                 repeat.for="navigation of navigations"
                 click.delegate="setActiveNavigation($index)"
                 class="tab flex-1 whitespace-nowrap ${activeNavigationIndex === $index ? 'tab-active' : ''}"
                 data-cy="cocktails-tab-${$index}">
-                <span data-cy="cocktails-tab-title-${$index}" t.bind="navigation.translation "></span>
+                <span t.bind="navigation.translation " data-cy="cocktails-tab-title-${$index}"></span>
             </a>
         </div>
     </header>

--- a/src/modules/home/home-router.html
+++ b/src/modules/home/home-router.html
@@ -21,7 +21,7 @@
         </div>
     </header>
 
-    <div class="pt-10 responsive-container pb-16">
+    <div class="pt-10 responsive-container pb-16 page-content">
         <div if.bind="router.currentInstruction.config.route !== ''" class="p-4 flex items-center">
             <icon-chevron-back click.delegate="router.navigateBack()" class="block w-6 h-6 mr-4"></icon-chevron-back>
             <h2 class="font-semibold text-xl" t.bind="router.currentInstruction.config.title"></h2>

--- a/src/modules/home/home-settings.ts
+++ b/src/modules/home/home-settings.ts
@@ -11,7 +11,8 @@ export class HomeSettings {
         { name: 'Navigation', id: Widget.Navigation },
         { name: 'Cocktails from Ingredients', id: Widget.IngredientWidget },
         { name: 'Random Cocktails', id: Widget.ExploreSection },
-        { name: 'Quick Add Ingredients', id: Widget.AddIngredients }
+        { name: 'Quick Add Ingredients', id: Widget.AddIngredients },
+        { name: 'Shopping List', id: Widget.ShoppingList }
     ];
 
     public widgetOrder: WidgetOrder[] = [];

--- a/src/modules/home/home.html
+++ b/src/modules/home/home.html
@@ -7,6 +7,7 @@
             <ingredients-widget css="${getOrderById(1)}" ingredient-ids.bind="ingredientIds"></ingredients-widget>
             <explore-section css="${getOrderById(0)}"> </explore-section>
             <add-ingredients css="${getOrderById(2)}" ingredient-ids.two-way="ingredientIds"></add-ingredients>
+            <shopping-list-widget css="${getOrderById(5)}"></shopping-list-widget>
         </div>
     </div>
 </template>

--- a/src/modules/ingredients/all-ingredients/all-ingredients.html
+++ b/src/modules/ingredients/all-ingredients/all-ingredients.html
@@ -7,27 +7,29 @@
                 <div class="ingredient-group-header bg-base-100">
                     <p>${group.letter.toUpperCase()}</p>
                 </div>
-                <div
-                    repeat.for="ingredient of group.items"
-                    click.delegate="toggleIngredient(ingredient)"
-                    class="ingredient-group-item au-animate animate-fade-in animate-fade-out"
-                    data-cy="ingredient-${ingredient.translation}">
-                    <p>${ingredient.name}</p>
-                    <svg
-                        show.bind="ingredient.isActive"
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-6 w-6 text-success"
-                        stroke="currentColor"
-                        viewBox="0 0 512 512">
-                        <title>Checkmark</title>
-                        <path
-                            fill="none"
+                <div class="ingredient-group-list">
+                    <div
+                        repeat.for="ingredient of group.items"
+                        click.delegate="toggleIngredient(ingredient)"
+                        class="ingredient-group-item au-animate animate-fade-in animate-fade-out"
+                        data-cy="ingredient-${ingredient.translation}">
+                        <p>${ingredient.name}</p>
+                        <svg
+                            show.bind="ingredient.isActive"
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="h-6 w-6 text-success"
                             stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="32"
-                            d="M416 128L192 384l-96-96" />
-                    </svg>
+                            viewBox="0 0 512 512">
+                            <title>Checkmark</title>
+                            <path
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="32"
+                                d="M416 128L192 384l-96-96" />
+                        </svg>
+                    </div>
                 </div>
                 <div class="divider"></div>
             </div>

--- a/src/modules/ingredients/ingredients.html
+++ b/src/modules/ingredients/ingredients.html
@@ -4,7 +4,7 @@
 
     <header class="bg-base-300">
         <h4 class="px-2 mb-1 pt-2" t="routes.ingredients"></h4>
-        <div class="tabs tabs-lifted overflow-x-scroll hide-scrollbar flex-nowrap">
+        <div class="tabs tabs-lifted overflow-x-scroll hide-scrollbar flex-nowrap w-full">
             <a
                 repeat.for="navigation of navigations"
                 click.delegate="setActiveNavigation($index)"

--- a/src/modules/ingredients/search-ingredients/search-ingredients.html
+++ b/src/modules/ingredients/search-ingredients/search-ingredients.html
@@ -4,26 +4,28 @@
         <div class="selected-ingredients-wrapper" data-cy="ingredient-list">
             <selected-ingredients-list-component></selected-ingredients-list-component>
 
-            <div
-                repeat.for="ingredient of selectedIngredients"
-                class="au-animate animate-fade-in animate-fade-out ingredient-group-item">
-                <p>${ingredient.name}</p>
-                <svg
-                    click.delegate="removeItem(ingredient)"
-                    xmlns="http://www.w3.org/2000/svg"
-                    class="h-6 w-6 text-secondary"
-                    stroke="currentColor"
-                    viewBox="0 0 512 512"
-                    data-cy="remove-${ingredient.translation}">
-                    <title>Close</title>
-                    <path
-                        fill="none"
+            <div class="ingredient-group-list">
+                <div
+                    repeat.for="ingredient of selectedIngredients"
+                    class="au-animate animate-fade-in animate-fade-out ingredient-group-item">
+                    <p>${ingredient.name}</p>
+                    <svg
+                        click.delegate="removeItem(ingredient)"
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="h-6 w-6 text-secondary"
                         stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="32"
-                        d="M368 368L144 144M368 144L144 368" />
-                </svg>
+                        viewBox="0 0 512 512"
+                        data-cy="remove-${ingredient.translation}">
+                        <title>Close</title>
+                        <path
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="32"
+                            d="M368 368L144 144M368 144L144 368" />
+                    </svg>
+                </div>
             </div>
         </div>
     </div>

--- a/src/modules/user/cocktails/user-cocktails.html
+++ b/src/modules/user/cocktails/user-cocktails.html
@@ -1,7 +1,11 @@
 <template>
     <div class="p-4 pt-0" data-cy="created-cockatails-container">
         <div class="flex justify-end items-center mb-3">
-            <button click.delegate="openDialog(null)" class="btn btn-secondary" t="add" data-cy="add-cocktail"></button>
+            <button
+                click.delegate="openDialog(null)"
+                class="btn btn-secondary"
+                t="add-cocktail"
+                data-cy="add-cocktail"></button>
         </div>
 
         <div class="cocktail-grid">

--- a/src/modules/user/ingredient-lists/ingredient-lists.html
+++ b/src/modules/user/ingredient-lists/ingredient-lists.html
@@ -4,7 +4,7 @@
             <button
                 click.delegate="openDialog(null)"
                 class="btn btn-secondary"
-                t="add"
+                t="add-ingredient-list"
                 data-cy="add-ingredient-list"></button>
         </div>
         <div data-cy="created-ingredient-lists-container">

--- a/src/modules/user/ingredient-substitutions/ingredient-substitutions.html
+++ b/src/modules/user/ingredient-substitutions/ingredient-substitutions.html
@@ -1,33 +1,161 @@
 <template>
     <div class="p-4 pt-0">
-        <div class="flex justify-end items-center mb-3"></div>
+        <div class="flex justify-end items-center mb-3">
+            <button click.delegate="openAddForm()" class="btn btn-sm btn-primary" data-cy="add-substitution">
+                <span t="add-substitution"></span>
+            </button>
+        </div>
+
         <div data-cy="ingredients-container">
-            <div class="flex items-center justify-start">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    class="stroke-info shrink-0 w-6 h-6 mr-1">
-                    <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                </svg>
-                <p class="text-sm ml-2" t="general-substitutions-paragraph"></p>
-            </div>
-            <div class="overflow-x-auto mt-4">
+            <div
+                if.bind="userSubstitutions.length === 0"
+                class="text-sm opacity-60 mt-4"
+                t="no-user-substitutions"
+                data-cy="no-user-substitutions"></div>
+
+            <div if.bind="userSubstitutions.length > 0" class="overflow-x-auto mt-4">
                 <table class="table table-zebra">
                     <tbody>
-                        <tr repeat.for="item of ingredients">
+                        <tr
+                            repeat.for="item of userSubstitutions"
+                            id="substitution-row-${item.id}"
+                            class="${item.id === highlightedIngredientId ? 'bg-primary bg-opacity-10' : ''}"
+                            data-cy="substitution-row-${item.id}">
                             <th>${item.name}</th>
-                            <td></td>
                             <td>
                                 <p repeat.for="substitution of item.substitutions" class="text-xs">${substitution}</p>
+                                <p if.bind="item.note" class="text-xs italic opacity-75">${item.note}</p>
+                            </td>
+                            <td class="text-right">
+                                <button
+                                    click.delegate="openEditForm(item)"
+                                    class="btn btn-sm btn-ghost"
+                                    data-cy="edit-substitution-${item.id}">
+                                    <icon-pencil class="h-5 w-5"></icon-pencil>
+                                </button>
                             </td>
                         </tr>
                     </tbody>
                 </table>
+            </div>
+
+            <details
+                ref="defaultsElement"
+                class="collapse collapse-arrow bg-base-200 mt-6"
+                data-cy="default-substitutions">
+                <summary class="collapse-title text-sm font-semibold" t="default-substitutions"></summary>
+                <div class="collapse-content">
+                    <div class="flex items-center justify-start mb-2">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            class="stroke-info shrink-0 w-6 h-6 mr-1">
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                        <p class="text-sm ml-2" t="general-substitutions-paragraph"></p>
+                    </div>
+                    <div class="overflow-x-auto">
+                        <table class="table table-zebra">
+                            <tbody>
+                                <tr
+                                    repeat.for="item of defaultSubstitutions"
+                                    id="substitution-row-${item.id}"
+                                    class="${item.id === highlightedIngredientId ? 'bg-primary bg-opacity-10' : ''}"
+                                    data-cy="default-substitution-row-${item.id}">
+                                    <th>${item.name}</th>
+                                    <td>
+                                        <p repeat.for="substitution of item.substitutions" class="text-xs">
+                                            ${substitution}
+                                        </p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </details>
+        </div>
+
+        <div click.delegate="closeForm()" show.bind="isFormOpen" class="search-overlay"></div>
+        <div
+            show.bind="isFormOpen"
+            class="fixed bottom-0 left-0 right-0 bg-base-100 p-4 rounded-t-2xl shadow-lg z-50"
+            data-cy="substitution-form">
+            <h5 class="font-bold mb-2" t="${editingIngredientId ? 'edit-substitution' : 'add-substitution'}"></h5>
+
+            <div class="form-control w-full">
+                <label class="label">
+                    <span class="label-text" t="ingredient"></span>
+                </label>
+                <select
+                    value.bind="selectedSourceId"
+                    disabled.bind="editingIngredientId"
+                    class="select select-bordered select-sm"
+                    data-cy="substitution-source-select">
+                    <option value="" t="select-ingredient"></option>
+                    <option repeat.for="ingredient of allIngredients" model.bind="ingredient.id">
+                        ${ingredient.name}
+                    </option>
+                </select>
+                <p
+                    if.bind="editingIngredientId"
+                    class="text-xs opacity-60 mt-1"
+                    t="substitution-ingredient-locked-hint"></p>
+            </div>
+
+            <div class="form-control w-full mt-2">
+                <label class="label">
+                    <span class="label-text" t="substitutes"></span>
+                </label>
+                <input
+                    type="search"
+                    value.bind="replacementFilter"
+                    placeholder="${'search' | t}"
+                    class="input input-bordered input-sm w-full mb-2"
+                    data-cy="substitution-replacement-filter" />
+                <div class="max-h-40 overflow-y-auto border border-base-300 rounded-md p-2">
+                    <label repeat.for="candidate of filteredReplacementCandidates" class="flex items-center gap-2 py-1">
+                        <input
+                            type="checkbox"
+                            checked.bind="selectedReplacementIds"
+                            model.bind="candidate.id"
+                            class="checkbox checkbox-sm"
+                            data-cy="substitution-replacement-checkbox-${candidate.id}" />
+                        <span class="text-sm">${candidate.name}</span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="form-control w-full mt-2">
+                <label class="label">
+                    <span class="label-text" t="substitution-note"></span>
+                </label>
+                <textarea
+                    value.bind="note"
+                    rows="2"
+                    class="textarea textarea-bordered w-full text-sm"
+                    data-cy="substitution-note-input"></textarea>
+            </div>
+
+            <div class="mt-4 flex justify-between">
+                <button click.delegate="closeForm()" class="btn btn-sm" t="cancel"></button>
+                <button
+                    if.bind="editingIngredientId"
+                    click.delegate="remove(editingIngredientId)"
+                    class="btn btn-sm btn-ghost text-error"
+                    t="delete"
+                    data-cy="delete-substitution"></button>
+                <button
+                    click.delegate="save()"
+                    disabled.bind="!canSave"
+                    class="btn btn-sm btn-primary"
+                    t="save"
+                    data-cy="save-substitution"></button>
             </div>
         </div>
     </div>

--- a/src/modules/user/ingredient-substitutions/ingredient-substitutions.ts
+++ b/src/modules/user/ingredient-substitutions/ingredient-substitutions.ts
@@ -1,14 +1,107 @@
-import { autoinject } from 'aurelia-framework';
-import { IngredientSubstitutionModel } from 'domain/entities/ingredient';
+import { autoinject, computedFrom } from 'aurelia-framework';
+import { Ingredient, IngredientSubstitutionModel } from 'domain/entities/ingredient';
 import { IngredientService } from 'services/ingredient-service';
 
 @autoinject()
 export class IngredientSubstitutes {
-    public ingredients: IngredientSubstitutionModel[] = [];
+    public userSubstitutions: IngredientSubstitutionModel[] = [];
+    public defaultSubstitutions: IngredientSubstitutionModel[] = [];
+    public allIngredients: Ingredient[] = [];
+    public highlightedIngredientId: string;
 
-    constructor(private ingredientService: IngredientService) {}
+    public isFormOpen = false;
+    public editingIngredientId: string;
+    public selectedSourceId = '';
+    public selectedReplacementIds: string[] = [];
+    public note = '';
+    public replacementFilter = '';
+    public defaultsElement: HTMLDetailsElement;
 
-    activate() {
-        this.ingredients = this.ingredientService.getIngredinetWithsubstitutions();
+    constructor(private _ingredientService: IngredientService) {}
+
+    activate(params: { ingredientId?: string }) {
+        this.highlightedIngredientId = params?.ingredientId;
+        this.load();
+    }
+
+    attached() {
+        if (!this.highlightedIngredientId) {
+            return;
+        }
+
+        if (this.defaultSubstitutions.some(x => x.id === this.highlightedIngredientId) && this.defaultsElement) {
+            this.defaultsElement.open = true;
+        }
+
+        const row = document.getElementById(`substitution-row-${this.highlightedIngredientId}`);
+        row?.scrollIntoView({ block: 'center' });
+    }
+
+    load() {
+        const ingredients = this._ingredientService.getIngredinetWithsubstitutions();
+        this.userSubstitutions = ingredients.filter(x => x.isUserDefined);
+        this.defaultSubstitutions = ingredients.filter(x => !x.isUserDefined);
+        this.allIngredients = this._ingredientService.getIngredients();
+    }
+
+    @computedFrom('allIngredients', 'selectedSourceId', 'replacementFilter')
+    get filteredReplacementCandidates(): Ingredient[] {
+        const filter = this.replacementFilter.trim().toLocaleLowerCase();
+
+        return this.allIngredients.filter(
+            x => x.id !== this.selectedSourceId && (!filter || x.name.toLocaleLowerCase().includes(filter))
+        );
+    }
+
+    openAddForm() {
+        this.isFormOpen = true;
+        this.editingIngredientId = undefined;
+        this.selectedSourceId = '';
+        this.selectedReplacementIds = [];
+        this.note = '';
+        this.replacementFilter = '';
+    }
+
+    openEditForm(item: IngredientSubstitutionModel) {
+        const existing = this._ingredientService.getUserSubstitution(item.id);
+
+        this.isFormOpen = true;
+        this.editingIngredientId = item.id;
+        this.selectedSourceId = item.id;
+        this.selectedReplacementIds = existing ? [...existing.replacementIds] : [];
+        this.note = existing?.note ?? '';
+        this.replacementFilter = '';
+    }
+
+    closeForm() {
+        this.isFormOpen = false;
+    }
+
+    // No @computedFrom: selectedReplacementIds is mutated in place by the native
+    // checkbox-array binding (checked.bind + model.bind), not reassigned, so a
+    // computed-from dependency on it would never re-evaluate. Dirty-checking does.
+    get canSave(): boolean {
+        return this.selectedSourceId !== '' && this.selectedReplacementIds.length > 0;
+    }
+
+    async save() {
+        if (!this.canSave) {
+            return;
+        }
+
+        await this._ingredientService.saveUserSubstitution(
+            this.selectedSourceId,
+            this.selectedReplacementIds,
+            this.note.trim() || undefined
+        );
+
+        this.isFormOpen = false;
+        this.load();
+    }
+
+    async remove(ingredientId: string) {
+        await this._ingredientService.deleteUserSubstitution(ingredientId);
+        this.isFormOpen = false;
+        this.load();
     }
 }

--- a/src/modules/user/ingredients/user-ingredients.html
+++ b/src/modules/user/ingredients/user-ingredients.html
@@ -4,7 +4,7 @@
             <button
                 click.delegate="openDialog(null)"
                 class="btn btn-secondary"
-                t="add"
+                t="add-ingredient"
                 data-cy="add-ingredient"></button>
         </div>
         <div data-cy="created-ingredients-container">

--- a/src/modules/user/shopping-list/user-shopping-lists.html
+++ b/src/modules/user/shopping-list/user-shopping-lists.html
@@ -5,7 +5,7 @@
             <button
                 click.delegate="createShoppingList()"
                 class="btn btn-secondary"
-                t="add"
+                t="add-shopping-list"
                 data-cy="add-shopping-list"></button>
         </div>
         <div data-cy="shopping-list-container">

--- a/src/modules/user/tags/user-tags.html
+++ b/src/modules/user/tags/user-tags.html
@@ -1,7 +1,7 @@
 <template>
     <div class="p-4 pt-0">
         <div class="flex justify-end items-center mb-3">
-            <button click.delegate="openDialog(null)" class="btn btn-secondary" t="add" data-cy="add-tag"></button>
+            <button click.delegate="openDialog(null)" class="btn btn-secondary" t="add-tag" data-cy="add-tag"></button>
         </div>
         <div data-cy="created-tags-container">
             <div

--- a/src/modules/user/user-page.ts
+++ b/src/modules/user/user-page.ts
@@ -30,6 +30,12 @@ export class UserPage {
             subtitle: 'shopping-list.subtitle',
             iconView: './../../components/icons/icon-reader.html',
             route: 'user-shopping-lists'
+        },
+        {
+            title: 'user.ingredient-substitutions-title',
+            subtitle: 'user.ingredient-substitutions-subtitle',
+            iconView: './../../components/icons/icon-repeat.html',
+            route: 'ingredient-substitutions'
         }
     ];
 
@@ -39,12 +45,6 @@ export class UserPage {
             subtitle: 'user.settings-subtitle',
             iconView: './../../components/icons/icon-settings.html',
             route: 'settings'
-        },
-        {
-            title: 'user.ingredient-substitutions-title',
-            subtitle: 'user.ingredient-substitutions-subtitle',
-            iconView: './../../components/icons/icon-repeat.html',
-            route: 'ingredient-substitutions'
         },
         {
             title: 'user.contact-title',

--- a/src/modules/user/user-router.html
+++ b/src/modules/user/user-router.html
@@ -1,9 +1,9 @@
 <template>
-    <header class="flex items-center fixed top-0 w-full bg-base-300 z-50 ios-fixed-topbar-fix">
+    <header class="user-header flex items-center fixed top-0 w-full bg-base-300 z-50 ios-fixed-topbar-fix">
         <p class="p-2" t="routes.user"></p>
     </header>
 
-    <div class="pt-10 responsive-container pb-16">
+    <div class="pt-10 responsive-container pb-16 page-content">
         <div if.bind="router.currentInstruction.config.route !== ''" class="p-4 flex items-center">
             <icon-chevron-back click.delegate="router.navigateBack()" class="block w-6 h-6 mr-4"></icon-chevron-back>
             <h2 class="font-semibold text-xl" t.bind="router.currentInstruction.config.title"></h2>

--- a/src/services/ingredient-service.ts
+++ b/src/services/ingredient-service.ts
@@ -5,7 +5,8 @@ import {
     CreatedIngredientModel,
     Ingredient,
     IngredientSubstitutionModel,
-    ManageIngredientModel
+    ManageIngredientModel,
+    UserSubstitution
 } from 'domain/entities/ingredient';
 import { SpiritType } from 'domain/enums/spirit-type';
 import { getStaticIngredients } from 'data/ingredient-data';
@@ -15,6 +16,7 @@ import { LocalStorageService } from './local-storage-service';
 export class IngredientService {
     private _ingredients: Ingredient[];
     private _createdIngredients: Ingredient[];
+    private _userSubstitutions: UserSubstitution[];
     private _highestId: number;
 
     constructor(
@@ -51,6 +53,16 @@ export class IngredientService {
             }
 
             this._ingredients.push(x);
+        });
+
+        this._userSubstitutions = this._localStorageService.getUserSubstitutions() ?? [];
+        this._userSubstitutions.forEach(sub => {
+            const ingredient = this._ingredients.find(x => x.id === sub.ingredientId);
+            if (ingredient === undefined) {
+                return;
+            }
+
+            ingredient.replacementIds = [...new Set([...(ingredient.replacementIds ?? []), ...sub.replacementIds])];
         });
     }
 
@@ -133,13 +145,31 @@ export class IngredientService {
         );
 
         const data = ingredientWithSubstitutes.map(x => {
+            const userSubstitution = this._userSubstitutions.find(y => y.ingredientId === x.id);
             return {
                 ...x,
-                substitutions: this.getSubstitutes(x)
+                substitutions: this.getSubstitutes(x),
+                note: userSubstitution?.note,
+                isUserDefined: userSubstitution !== undefined
             };
         });
 
         return data;
+    }
+
+    public async saveUserSubstitution(ingredientId: string, replacementIds: string[], note?: string) {
+        this._userSubstitutions = this._userSubstitutions.filter(x => x.ingredientId !== ingredientId);
+        this._userSubstitutions.push({ ingredientId, replacementIds, note });
+
+        await this._localStorageService.updateUserSubstitutions(this._userSubstitutions);
+        this.reloadService();
+    }
+
+    public async deleteUserSubstitution(ingredientId: string) {
+        this._userSubstitutions = this._userSubstitutions.filter(x => x.ingredientId !== ingredientId);
+
+        await this._localStorageService.updateUserSubstitutions(this._userSubstitutions);
+        this.reloadService();
     }
 
     public async createIngredient(request: CreateIngredientRequest) {
@@ -211,14 +241,24 @@ export class IngredientService {
         return 'x-' + this._highestId;
     }
 
+    public getUserSubstitution(ingredientId: string): UserSubstitution {
+        return this._userSubstitutions.find(x => x.ingredientId === ingredientId);
+    }
+
     private getSubstitutes(ingredient: Ingredient): string[] {
         const names: string[] = [];
 
         ingredient?.replacementIds?.forEach(x => {
-            const translation = this._ingredients.find(y => y.id === x).translation;
-            if (translation !== undefined) {
-                names.push(this._i18n.tr(translation, { ns: 'ingredients' }));
+            const substitute = this._ingredients.find(y => y.id === x);
+            if (substitute === undefined) {
+                return;
             }
+
+            names.push(
+                substitute.translation !== undefined
+                    ? this._i18n.tr(substitute.translation, { ns: 'ingredients' })
+                    : substitute.name
+            );
         });
 
         return names;

--- a/src/services/local-storage-service.ts
+++ b/src/services/local-storage-service.ts
@@ -2,7 +2,7 @@ import { Preferences } from '@capacitor/preferences';
 import { MessuarementSystem } from 'domain/enums/messuarement-system';
 import { Cocktail } from 'domain/entities/cocktail';
 import { WidgetOrder } from 'domain/entities/widget-order';
-import { Ingredient } from 'domain/entities/ingredient';
+import { Ingredient, UserSubstitution } from 'domain/entities/ingredient';
 import { SettingEntity } from 'domain/entities/setting-entity';
 import { CocktailInformation } from 'domain/entities/cocktail-information';
 import { TagModel } from 'domain/entities/cocktail-tag';
@@ -18,6 +18,7 @@ export class LocalStorageService {
     private _widgetOrder: WidgetOrder[] = [];
     private _cocktails: Cocktail[] = [];
     private _ingredients: Ingredient[] = [];
+    private _userSubstitutions: UserSubstitution[] = [];
     private _settings: SettingEntity;
     private _cocktailInformation: CocktailInformation[] = [];
     private _tags: TagModel[] = [];
@@ -58,6 +59,9 @@ export class LocalStorageService {
         const ingredients = await this.getFromLocalStorage(StorageKey.Ingredients);
         this._ingredients = ingredients !== null ? ingredients : [];
 
+        const userSubstitutions = await this.getFromLocalStorage(StorageKey.UserSubstitutions);
+        this._userSubstitutions = userSubstitutions !== null ? userSubstitutions : [];
+
         const settings = await this.getFromLocalStorage(StorageKey.Settings);
         this._settings = settings !== null ? new SettingEntity(settings) : new SettingEntity();
 
@@ -97,6 +101,11 @@ export class LocalStorageService {
     public async updateIngredients(ingredients: Ingredient[]) {
         await this.updateKey(StorageKey.Ingredients, JSON.stringify(ingredients));
         this._ingredients = ingredients;
+    }
+
+    public async updateUserSubstitutions(userSubstitutions: UserSubstitution[]) {
+        await this.updateKey(StorageKey.UserSubstitutions, JSON.stringify(userSubstitutions));
+        this._userSubstitutions = userSubstitutions;
     }
 
     public async updateIngredientList(ingredientList: IngredientList) {
@@ -181,6 +190,10 @@ export class LocalStorageService {
 
     public getIngredients() {
         return this._ingredients;
+    }
+
+    public getUserSubstitutions() {
+        return this._userSubstitutions;
     }
 
     public getIngredientLists() {
@@ -319,6 +332,7 @@ export enum StorageKey {
     WidgetOrder = 'widget-order',
     Cocktails = 'cocktails',
     Ingredients = 'ingredients',
+    UserSubstitutions = 'user-substitutions',
     Settings = 'settings',
     CocktailInformation = 'cocktail-information',
     Tags = 'tags',

--- a/tests/modules/user/ingredient-substitutions.test.ts
+++ b/tests/modules/user/ingredient-substitutions.test.ts
@@ -1,0 +1,126 @@
+import { IngredientSubstitutes } from 'modules/user/ingredient-substitutions/ingredient-substitutions';
+import { IngredientService } from 'services/ingredient-service';
+import { LocalStorageService } from 'services/local-storage-service';
+import { I18N } from 'aurelia-i18n';
+import { expect } from '@jest/globals';
+
+describe('IngredientSubstitutes', () => {
+    let ingredientService: IngredientService;
+    let sut: IngredientSubstitutes;
+
+    beforeEach(async () => {
+        const i18n = new I18N(null, null);
+        jest.spyOn(i18n, 'tr').mockReturnValue('name');
+
+        const localStorageService = new LocalStorageService();
+        await localStorageService.initialize();
+
+        ingredientService = new IngredientService(localStorageService, i18n);
+        sut = new IngredientSubstitutes(ingredientService);
+    });
+
+    afterEach(() => {
+        window.localStorage.clear();
+    });
+
+    test('activate - loads substitutions and highlighted ingredient', () => {
+        sut.activate({ ingredientId: '2' });
+
+        expect(sut.highlightedIngredientId).toBe('2');
+        expect(sut.defaultSubstitutions.find(x => x.id === '2')).toBeDefined();
+        expect(sut.allIngredients.length).toBeGreaterThan(0);
+    });
+
+    test('openAddForm - resets form state', () => {
+        sut.activate({});
+        sut.selectedSourceId = '8';
+        sut.selectedReplacementIds = ['106'];
+        sut.note = 'leftover';
+
+        sut.openAddForm();
+
+        expect(sut.isFormOpen).toBe(true);
+        expect(sut.editingIngredientId).toBeUndefined();
+        expect(sut.selectedSourceId).toBe('');
+        expect(sut.selectedReplacementIds).toStrictEqual([]);
+        expect(sut.note).toBe('');
+    });
+
+    test('openEditForm - prefills from existing user substitution', async () => {
+        await ingredientService.saveUserSubstitution('8', ['106'], 'Vesper note');
+        sut.activate({});
+
+        const item = sut.userSubstitutions.find(x => x.id === '8');
+        sut.openEditForm(item);
+
+        expect(sut.isFormOpen).toBe(true);
+        expect(sut.editingIngredientId).toBe('8');
+        expect(sut.selectedSourceId).toBe('8');
+        expect(sut.selectedReplacementIds).toStrictEqual(['106']);
+        expect(sut.note).toBe('Vesper note');
+    });
+
+    test('canSave - false without source or replacements, true once both set', () => {
+        sut.activate({});
+        sut.openAddForm();
+
+        expect(sut.canSave).toBe(false);
+
+        sut.selectedSourceId = '8';
+        expect(sut.canSave).toBe(false);
+
+        // Mirrors what the native checkbox-array binding does: mutate in place, not reassign
+        sut.selectedReplacementIds.push('106');
+        expect(sut.canSave).toBe(true);
+    });
+
+    test('filteredReplacementCandidates - excludes source ingredient and applies text filter', () => {
+        sut.activate({});
+        sut.selectedSourceId = '8';
+        sut.replacementFilter = '';
+
+        expect(sut.filteredReplacementCandidates.some(x => x.id === '8')).toBe(false);
+
+        sut.replacementFilter = 'zzz-does-not-exist';
+        expect(sut.filteredReplacementCandidates).toStrictEqual([]);
+    });
+
+    test('save - persists substitution and closes form', async () => {
+        sut.activate({});
+        sut.openAddForm();
+        sut.selectedSourceId = '8';
+        sut.selectedReplacementIds = ['106'];
+        sut.note = 'test note';
+
+        await sut.save();
+
+        expect(sut.isFormOpen).toBe(false);
+        expect(ingredientService.getUserSubstitution('8')).toStrictEqual({
+            ingredientId: '8',
+            replacementIds: ['106'],
+            note: 'test note'
+        });
+        expect(sut.userSubstitutions.find(x => x.id === '8')).toBeDefined();
+    });
+
+    test('save - no-op when form is invalid', async () => {
+        sut.activate({});
+        sut.openAddForm();
+
+        await sut.save();
+
+        expect(sut.isFormOpen).toBe(true);
+        expect(ingredientService.getUserSubstitution('8')).toBeUndefined();
+    });
+
+    test('remove - deletes user substitution and reloads list', async () => {
+        await ingredientService.saveUserSubstitution('8', ['106']);
+        sut.activate({});
+
+        await sut.remove('8');
+
+        expect(ingredientService.getUserSubstitution('8')).toBeUndefined();
+        expect(sut.userSubstitutions.find(x => x.id === '8')).toBeUndefined();
+        expect(sut.defaultSubstitutions.find(x => x.id === '8')).toBeUndefined();
+    });
+});

--- a/tests/services/ingredient-service.test.ts
+++ b/tests/services/ingredient-service.test.ts
@@ -95,4 +95,63 @@ describe('IngredientService', () => {
             expect(sut.getIngredientById(ingredient.id)).toBeUndefined();
         });
     });
+
+    describe('User substitutions', () => {
+        test('No user substitutions - built in substitutes still returned', () => {
+            // Ingredient '2' (lime-juice) has a static replacementId of '106' (lime)
+            const limeJuice = sut.getIngredinetWithsubstitutions().find(x => x.id === '2');
+
+            expect(limeJuice).toBeDefined();
+            expect(limeJuice.isUserDefined).toBe(false);
+            expect(limeJuice.note).toBeUndefined();
+            expect(sut.getUserSubstitution('2')).toBeUndefined();
+        });
+
+        test('Save user substitution - adds substitute and note, resolves custom ingredient name', async () => {
+            const cocchi = await sut.createIngredient({ name: 'Cocchi Americano' });
+
+            // Ingredient '8' (vodka) has no static substitutes
+            await sut.saveUserSubstitution('8', [cocchi.id], 'Great in a Vesper');
+
+            const vodka = sut.getIngredinetWithsubstitutions().find(x => x.id === '8');
+
+            expect(vodka).toBeDefined();
+            expect(vodka.isUserDefined).toBe(true);
+            expect(vodka.note).toBe('Great in a Vesper');
+            expect(vodka.substitutions).toContain('Cocchi Americano');
+            expect(sut.getIngredientAndReplacementIds('8')).toContain(cocchi.id);
+        });
+
+        test('Save user substitution - persists to local storage', async () => {
+            const key = 'CapacitorStorage.user-substitutions';
+            expect(window.localStorage.getItem(key)).toBeNull();
+
+            await sut.saveUserSubstitution('8', ['106']);
+
+            expect(window.localStorage.getItem(key)).toBeTruthy();
+            expect(localStorageService.getUserSubstitutions()).toStrictEqual([
+                { ingredientId: '8', replacementIds: ['106'], note: undefined }
+            ]);
+        });
+
+        test('Save user substitution twice for same ingredient - replaces previous entry', async () => {
+            await sut.saveUserSubstitution('8', ['106'], 'first');
+            await sut.saveUserSubstitution('8', ['105'], 'second');
+
+            expect(sut.getUserSubstitution('8')).toStrictEqual({
+                ingredientId: '8',
+                replacementIds: ['105'],
+                note: 'second'
+            });
+        });
+
+        test('Delete user substitution - removes it', async () => {
+            await sut.saveUserSubstitution('8', ['106']);
+
+            await sut.deleteUserSubstitution('8');
+
+            expect(sut.getUserSubstitution('8')).toBeUndefined();
+            expect(sut.getIngredinetWithsubstitutions().find(x => x.id === '8')).toBeUndefined();
+        });
+    });
 });

--- a/tests/services/local-storage-service.test.ts
+++ b/tests/services/local-storage-service.test.ts
@@ -35,4 +35,16 @@ describe('LocalStorageService', () => {
         const result = await sut.keyExists(StorageKey.MessuarementSystem);
         expect(result).toBe(true);
     });
+
+    test('User substitutions - No initial state, returns empty array', () => {
+        expect(sut.getUserSubstitutions()).toStrictEqual([]);
+    });
+
+    test('User substitutions - Update and get', async () => {
+        const userSubstitutions = [{ ingredientId: '8', replacementIds: ['106'], note: 'test' }];
+
+        await sut.updateUserSubstitutions(userSubstitutions);
+
+        expect(sut.getUserSubstitutions()).toStrictEqual(userSubstitutions);
+    });
 });


### PR DESCRIPTION
## Summary
- New "My Substitutions" page: add/edit/delete custom ingredient substitutions, browse built-in substitutions
- Cocktail dialog: long-press an ingredient row to open substitutes/storage actions; substitutes navigation moved off the tappable row label to avoid accidental navigation, and is only offered when substitutes exist
- New shopping list widget on the home screen; fixed it rendering wider than the viewport
- Substitutions list: bigger edit button, delete moved into the edit dialog (was a separate row action)
- Fixed a layout bug where the (invisible) toast container could intercept clicks on fixed bottom-sheet dialogs

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx jest` (54/54 passing)
- [x] `npx cypress run --spec cypress/e2e/ingredient-substitutions.cy.ts` (4/4 passing)
- [ ] Manual smoke test in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)